### PR TITLE
Fixed missing --build-arg in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Build with optional build arguments, (see the argument names and default values 
 $ docker-compose build
 
 # or with custom values
-$ docker-compose build --build-arg PORT=9999 --build-arg USERNAME=user PASSWORD=some-password
+$ docker-compose build --build-arg PORT=9999 --build-arg USERNAME=user --build-arg PASSWORD=some-password
 ```
 
 then run with:


### PR DESCRIPTION
README.md had a missing --build-arg in the code snippet for building the image using docker-compose. It's fixed now.